### PR TITLE
fix: resize handle showing in reading mode

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -84,8 +84,13 @@
     cursor: row-resize;
 }
 
-.workspace-split.mod-root .workspace-leaf:last-child .block-language-markmap .workspace-leaf-resize-handle,
-                          .workspace-tabs:last-child .block-language-markmap .workspace-leaf-resize-handle
+/* display inline mindmap resize handle in editing mode */
+/* override a rule in the obsidian stylesheet which hides workspace-leaf-resize-handle */
+.workspace-split.mod-root
+.workspace-leaf:last-child
+.workspace-leaf-content[data-mode=source] /* editing mode */
+.block-language-markmap
+.workspace-leaf-resize-handle
 { display: block }
 
 


### PR DESCRIPTION
The resize handle for inline mindmaps was displaying in reading mode, but attached to the bottom of the window instead of the bottom of the mindmap.

This pr stops the resize handle displaying entirely in reading mode.
