### PR TITLE
ops: bug report template: ask for markdown doc

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,6 +20,9 @@ Steps to reproduce the behavior:
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
+**Documents**
+If applicable, attach a markdown document that triggers the bug.
+
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 


### PR DESCRIPTION
Add a line to the bug report template that requests the reporter provide a document that demonstrates the bug.