### PR TITLE
fix: colon not allowed in internal link url hash

### DIFF
--- a/src/internal-links/catch-internal-links.ts
+++ b/src/internal-links/catch-internal-links.ts
@@ -15,7 +15,7 @@ export const catchInternalLinks = (plugin: Plugin) => {
       if (!parentMindmap) return
     const href = target.getAttribute('href')
       if (!href) return
-    const hasProtocol = /:/.test(href)
+    const hasProtocol = /^[^#:]*:.*#/.test(href)  // https://regex101.com/r/RLG0a5/1
       if (hasProtocol) return
 
     event.preventDefault()


### PR DESCRIPTION
This changes the regex that determines if a link is treated as internal or external.
Previously it disallowed all colons.
Now colons are allowed after the hash