### PR TITLE
Fix: Resolve 'Buffer is not defined' error for mobile devices (android)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An Obsidian plugin for displaying markdown notes as mindmaps using Markmap",
   "scripts": {
     "dev": "webpack --mode development --watch",
-    "build": "webpack --mode production",
+    "build": "node --loader ts-node/esm ./node_modules/webpack/bin/webpack.js --mode production",
     "coverage": "nyc -r lcov -e .ts -x \"*.test.ts\" npm run test",
     "test": "vitest"
   },
@@ -18,6 +18,7 @@
     "@types/node": "^22.10.7",
     "@types/ramda": "^0.30.2",
     "@typescript-eslint/parser": "^8.21.0",
+    "buffer": "^6.0.3",
     "eslint": "^9.18.0",
     "moment": "^2.29.4",
     "nyc": "^17.1.0",
@@ -62,6 +63,7 @@
     "markmap-toolbar": "^0.18.9",
     "markmap-view": "^0.18.9",
     "ramda": "^0.30.1",
+    "ts-node": "^10.9.2",
     "tsconfig-paths-webpack-plugin": "^4.2.0",
     "vitest": "^3.0.4",
     "webpack": "^5.97.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,11 @@
     },
     "types": ["vitest/globals"]
   },
+  "ts-node": {
+    "compilerOptions": {
+    },
+    "esm": true
+  },
   "include": [
     "**/*.ts",
     "src/types"

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -4,6 +4,10 @@ import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin'
 import { type Configuration } from 'webpack'
 import webpack from 'webpack'
 import ForkTsCheckerPlugin from 'fork-ts-checker-webpack-plugin'
+import { Buffer } from 'buffer'
+import { createRequire } from 'module'
+
+const require = createRequire(import.meta.url)
 
 export default (env, argv): Configuration => ({
   mode: getMode(argv.mode),
@@ -15,9 +19,11 @@ export default (env, argv): Configuration => ({
   },
   resolve: {
     extensions: ['.ts', '.js'],
-    plugins: [new TsconfigPathsPlugin]
+    plugins: [new TsconfigPathsPlugin],
+    fallback: { 
+      buffer: require.resolve('buffer/')
+    }
   },
-  target: 'node',
   module: {
     rules: [
       {
@@ -28,6 +34,9 @@ export default (env, argv): Configuration => ({
   },
   plugins: [
     new webpack.optimize.LimitChunkCountPlugin({ maxChunks: 1 }),
+    new webpack.ProvidePlugin({
+      Buffer: ['buffer', 'Buffer'],
+    }),
     new CopyPlugin({
       patterns: [
         { from: 'styles.css', to: '.' },


### PR DESCRIPTION
## Fix: Resolve 'Buffer is not defined' error for browser/mobile compatibility

**Problem:**

This PR addresses a `ReferenceError: Buffer is not defined` that occurs when running the plugin in non-Node.js environments, such as Obsidian mobile (tested on Android) or potentially web browsers. This error prevents the plugin from loading or functioning correctly in these environments.

**Solution:**

The root cause appears to be the build configuration targeting or assuming a Node.js environment. This leads to issues when dependencies (potentially `gray-matter` or others involved in processing) rely on Node-specific globals like `Buffer`.

This PR adjusts the build configuration files (`webpack.config.ts`, `tsconfig.json`, `package.json`) to produce a build compatible with standard browser/JavaScript environments where `Buffer` is not natively available. The primary change involved ensuring the Webpack build does not explicitly target Node.js.

**Testing:**

Manually tested on an Android tablet where the error previously occurred consistently. After applying these changes and rebuilding, the plugin loads and functions without the `Buffer` reference error.

**Related Issues:**

*(Optional: If this PR fixes an existing issue reported on the original repository, uncomment and replace `#issue_number` below)*
<!-- Fixes #issue_number -->
