### PR TITLE
update file translation for tooltips in CN

### DIFF
--- a/src/translation/zh-simplified.ts
+++ b/src/translation/zh-simplified.ts
@@ -16,8 +16,8 @@ export default {
       unpin: '取消固定',
     }
   },
-  fileSettingsButton: '编辑思维导图',
-  blockSettingsButton: 'Edit block settings',
+  fileSettingsButton: '文件级别设置',
+  blockSettingsButton: '代码框级别设置',
   settings: {
     explanations: {
       file: [

--- a/src/translation/zh-traditional.ts
+++ b/src/translation/zh-traditional.ts
@@ -16,8 +16,8 @@ export default {
       unpin: '取消固定',
     }
   },
-  fileSettingsButton: '編輯思維導圖',
-  blockSettingsButton: 'Edit block settings',
+  fileSettingsButton: '文件級別設置',
+  blockSettingsButton: '代碼框級別設置',
   settings: {
     explanations: {
       file: [


### PR DESCRIPTION
I just updated the translation of the tooltip text (?) for buttons as shown below. I thought the button has text (i.e., global, file, block) on it so I didn't translate the term "file" or "block" in the original translation.